### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##ReactiveCocoa TableView Binding Helper
+## ReactiveCocoa TableView Binding Helper
 
 This project contains a simple helper class that can be used to bind array properties on ReactiveCocoa view models to table views. Here's a quick example of how to use it:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
